### PR TITLE
Fix event handler logic

### DIFF
--- a/lib/BarcodeScanner.js
+++ b/lib/BarcodeScanner.js
@@ -15,7 +15,7 @@ export class BarcodeScanner {
             this.opened = false;
             this.start_reading = false;
             this.start_scanning = false;
-            this.oncallbacks = [];
+            this.oncallbacks = {};
             this.config = {}
 
             DeviceEventEmitter.addListener('BarcodeEvent', this.handleBarcodeEvent.bind(this));
@@ -39,7 +39,7 @@ export class BarcodeScanner {
     }
 
     handleBarcodeEvent(barcode) {
-        if (this.oncallbacks.hasOwnProperty(BarcodeScannerEvent.BARCODE)){
+        if (this.oncallbacks[BarcodeScannerEvent.BARCODE]){
             this.oncallbacks[BarcodeScannerEvent.BARCODE].forEach((funct, index) => {
                 funct(barcode);
             });
@@ -47,7 +47,7 @@ export class BarcodeScanner {
     }
 
     handleBarcodesEvent(barcodes) {
-        if (this.oncallbacks.hasOwnProperty(BarcodeScannerEvent.BARCODES)){
+        if (this.oncallbacks[BarcodeScannerEvent.BARCODES]){
             this.oncallbacks[BarcodeScannerEvent.BARCODES].forEach((funct, index) => {
                 funct(barcodes);
             });
@@ -100,27 +100,18 @@ export class BarcodeScanner {
     } 
 
     removeon(event, callback) {
-        if (this.oncallbacks.hasOwnProperty(event)){
-            this.oncallbacks[event].forEach((funct, index) => {
-                if (funct.toString() == callback.toString()){
-                    this.oncallbacks[event].splice(index, 1);
-                }
-            });
+        if (this.oncallbacks[event]){
+            this.oncallbacks[event] = this.oncallbacks[event].filter(funct => funct !== callback);
         }
     }
 
     hason(event, callback) {
-        let result = false;
-        if (this.oncallbacks.hasOwnProperty(event)){
-            this.oncallbacks[event].forEach((funct, index) => {
-                if (funct.toString() === callback.toString()){
-                    result = true;
-                }
-            });
+        if (this.oncallbacks[event]){
+            return this.oncallbacks[event].any(funct => funct === callback)
+        } else {
+            return false;
         }
-        return result;
     }
-    
 }
 
 export default new BarcodeScanner();


### PR DESCRIPTION
The original author had some...uh, interesting Javascript choices when writing the event handler logic for `BarcodeScanner`. This PR makes saner decisions and, more notably, fixes a bug where using Array.prototype.splice` inside of a `forEach` causes the loop to be aborted early